### PR TITLE
Prevent error when undocumented combat log event behavior causes `spellName` to be a table with a `name` field instead of a string. This happens when a player uses Reincarnation, for example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -181,6 +181,15 @@
         "CombatText_StandardScroll",
         "UIErrorsFrame",
         "RaidNotice_AddMessage",
-        "RaidWarningFrame"
+        "RaidWarningFrame",
+        "CopyTable",
+        "GameTooltip",
+        "RAID_CLASS_COLORS",
+        "UIParent",
+        "LOCALIZED_CLASS_NAMES_MALE",
+        "COMBATLOG_OBJECT_RAIDTARGET_MASK",
+        "COMBATLOG_OBJECT_REACTION_FRIENDLY",
+        "COMBATLOG_OBJECT_REACTION_HOSTILE",
+        "COMBATLOG_OBJECT_TYPE_GUARDIAN"
     ]
 }

--- a/Core.lua
+++ b/Core.lua
@@ -506,6 +506,9 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 
 		spellID, spellName, spellSchool, SuffixParam1, SuffixParam2, SuffixParam3, SuffixParam4, SuffixParam5, SuffixParam6, SuffixParam7, SuffixParam8, SuffixParam9 = select(12, unpack(CLEU))
 		args.amount = SuffixParam1
+		if spellName.name then
+			spellName = spellName.name
+		end
 
 	-------------
 	--- Spell ---

--- a/Core.lua
+++ b/Core.lua
@@ -52,7 +52,7 @@ local death = {
 	overkill = {}, -- unit guids that supposedly died from overkill; table: cleu event
 	damage = {}, -- unit guids with their last known dmg event; table: cleu event
 	deleted = {}, -- unit guids that got cleaved by High Overlord Saurfang; boolean
-	
+
 	cheater = {}, -- unit guids that are cheating death; cleu event
 	whosyourdaddy = {}, -- cheaters get to skip the delta check; boolean
 }
@@ -64,7 +64,7 @@ local selfres = {
 	soulstone = {}, -- Warlock Soulstone
 	soulstone_source = {}, -- merge source args for the original Soulstone caster
 	reincarnation = {}, -- Shaman Reincarnation
-	
+
 	prevHealth = {}, -- compare to current health for delta
 	wasDead = {}, -- double confirm unit was actually dead before selfres
 }
@@ -109,30 +109,30 @@ local appValue = {
 
 function KCL:OnInitialize()
 	self.db = LibStub("AceDB-3.0"):New("KethoCombatLogDB", S.defaults, true)
-	
+
 	self.db.RegisterCallback(self, "OnProfileChanged", "RefreshDB")
 	self.db.RegisterCallback(self, "OnProfileCopied", "RefreshDB")
 	self.db.RegisterCallback(self, "OnProfileReset", "RefreshDB")
 	self:RefreshDB()
-	
+
 	-- parent options table
 	ACR:RegisterOptionsTable("KethoCombatLog_Parent", options)
 	ACD:AddToBlizOptions("KethoCombatLog_Parent", NAME)
-	
+
 	-- profiles
 	options.args.profiles = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db)
 	local profiles = options.args.profiles
 	appValue.KethoCombatLog_Profiles = profiles
 	profiles.order = 6
 	profiles.name = "|TInterface\\Icons\\INV_Misc_Note_01:16:16:0:-1"..S.crop.."|t  "..profiles.name
-	
+
 	for _, v in ipairs(appKey) do
 		ACR:RegisterOptionsTable(v, appValue[v])
 		ACD:AddToBlizOptions(v, appValue[v].name, NAME)
 	end
-	
+
 	ACD:SetDefaultSize("KethoCombatLog_Parent", 600, 520)
-	
+
 	-- slash command
 	for _, v in ipairs({"kcl", "ket", "ketho", "kethocombat", "kethocombatlog"}) do
 		self:RegisterChatCommand(v, "SlashCommand")
@@ -143,11 +143,11 @@ function KCL:OnEnable()
 	-- controls COMBAT_LOG_EVENT_UNFILTERED
 	self:RegisterEvent("ZONE_CHANGED_NEW_AREA")
 	self:ZONE_CHANGED_NEW_AREA()
-	
+
 	-- controls chatType
 	self:RegisterEvent("GROUP_ROSTER_UPDATE")
 	self:GROUP_ROSTER_UPDATE()
-	
+
 	-- support [Class Colors] by Phanx
 	if CUSTOM_CLASS_COLORS then
 		CUSTOM_CLASS_COLORS:RegisterCallback("WipeCache", self)
@@ -157,7 +157,7 @@ end
 function KCL:OnDisable()
 	-- maybe superfluous
 	self:UnregisterAllEvents()
-	
+
 	if CUSTOM_CLASS_COLORS then
 		CUSTOM_CLASS_COLORS:UnregisterCallback("WipeCache", self)
 	end
@@ -167,7 +167,7 @@ function KCL:RefreshDB()
 	-- table shortcuts
 	profile = self.db.profile
 	color = profile.color
-	
+
 	for i = 1, 2 do -- refresh db in other files
 		self["RefreshDB"..i](self)
 	end
@@ -175,7 +175,7 @@ function KCL:RefreshDB()
 	self:SetSinkStorage(profile) -- LibSink
 	self:RefreshEvent() -- options dependent event
 	self:RefreshSpell() -- options dependent spells lookup
-	
+
 	-- other
 	S.crop = profile.IconCropped and ":64:64:4:60:4:60" or ""
 	if profile.ChatWindow > 1 then
@@ -252,18 +252,18 @@ end
 
 function KCL:ZONE_CHANGED_NEW_AREA(event)
 	local _, instanceType = IsInInstance()
-	
+
 	local pve = profile.PvE and S.PvE[instanceType]
 	local pvp = profile.PvP and S.PvP[instanceType]
 	local world = profile.World and instanceType == "none"
 	isBattleground = (instanceType == "pvp")
-	
+
 	self[(pve or pvp or world) and "RegisterEvent" or "UnregisterEvent"](self, "COMBAT_LOG_EVENT_UNFILTERED")
 end
 
 function KCL:GROUP_ROSTER_UPDATE(event)
 	local p = profile.ChatChannel
-	
+
 	if p == 2 then
 		chatType = "SAY"
 	elseif p == 3 then
@@ -298,7 +298,7 @@ end
 local function UnitIcon(unitFlags, reaction)
 	local raidTarget = bit_band(unitFlags, COMBATLOG_OBJECT_RAIDTARGET_MASK)
 	if raidTarget == 0 then return "", "" end
-	
+
 	local i = S.COMBATLOG_OBJECT_RAIDTARGET[raidTarget]
 	local icon = _G["COMBATLOG_ICON_RAIDTARGET"..i]
 	local iconString = format(S.STRING_REACTION_ICON[reaction], raidTarget, icon)
@@ -366,12 +366,12 @@ local function GetResultString(overkill, critical, glancing, crushing)
 		str = str.." "..TEXT_MODE_A_STRING_RESULT_CRITICAL
 	end
 	if glancing and profile.GlancingFormat then
-		str = str.." "..TEXT_MODE_A_STRING_RESULT_GLANCING 
+		str = str.." "..TEXT_MODE_A_STRING_RESULT_GLANCING
 	end
 	if crushing and profile.CrushingFormat then
-		str = str.." "..TEXT_MODE_A_STRING_RESULT_CRUSHING 
+		str = str.." "..TEXT_MODE_A_STRING_RESULT_CRUSHING
 	end
-	
+
 	return str
 end
 
@@ -458,22 +458,22 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 	-- 8.0.1: this recursion is totally fucked up
 	local CLEU = ... and {...} or {CombatLogGetCurrentEventInfo()}
 	local timestamp, subevent, hideCaster, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags = unpack(CLEU)
-	
+
 	wipe(args) -- wipe substitution args
-	
+
 	local sourceType = strsplit("-", sourceGUID)
 	local destType = strsplit("-", destGUID)
-	
+
 	local sourcePlayer = (sourceType == "Player")
 	local destPlayer = (destType == "Player")
-	
+
 	--------------
 	--- Filter ---
 	--------------
-	
+
 	local isMissEvent = (S.MissEvent[subevent] and S.MissType[select(15, unpack(CLEU))])
  	local isReverseEvent = S.DamageEvent[subevent] or isMissEvent or subevent == "UNIT_DIED"
-	
+
 	-- players, pets, npcs
 	if sourcePlayer or (isReverseEvent and destPlayer) then
 		if not profile.FilterPlayers then return end
@@ -482,20 +482,20 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 	else
 		if not profile.FilterMonsters then return end
 	end
-	
+
 	-- ignore training dummies
 	if destType == "Creature" then
 		local destNPC = tonumber( (select(6, strsplit("-", destGUID))) )
 		if S.TrainingDummy[destNPC] then return end
 	end
-	
+
 	--------------
 	--- Suffix ---
 	--------------
-	
+
 	local spellID, spellName, spellSchool
 	local SuffixParam1, SuffixParam2, SuffixParam3, SuffixParam4, SuffixParam5, SuffixParam6, SuffixParam7, SuffixParam8, SuffixParam9
-	
+
 	local prefix = strsub(subevent, 1, 5)
 	if prefix == "SWING" then
 		SuffixParam1, SuffixParam2, SuffixParam3, SuffixParam4, SuffixParam5, SuffixParam6, SuffixParam7, SuffixParam8, SuffixParam9 = select(12, unpack(CLEU))
@@ -503,37 +503,37 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 	elseif S.SpellPrefix[prefix] then
 		-- not sure what happened here in WoD; two same dest units apparently
 		if subevent == "SPELL_ABSORBED" then return end
-		
+
 		spellID, spellName, spellSchool, SuffixParam1, SuffixParam2, SuffixParam3, SuffixParam4, SuffixParam5, SuffixParam6, SuffixParam7, SuffixParam8, SuffixParam9 = select(12, unpack(CLEU))
 		args.amount = SuffixParam1
-		
+
 	-------------
 	--- Spell ---
 	-------------
-		
+
 		args.school, args.schoolx, args.spell, args.spellx = _GetSpellInfo(spellID, spellName, spellSchool)
 		args.spellname = format("[%s]", spellName)
-		
+
 		if profile.SpellNotClickable then -- by user request
 			args.spell, args.spellx = format("[%s]", spellName), format("[%s]", spellName)
 		end
-		
+
 		if S.ExtraSpellEvent[subevent] then
 			args.xschool, args.xschoolx, args.xspell, args.xspellx = _GetSpellInfo(SuffixParam1, SuffixParam2, SuffixParam3)
 			args.xspellname = format("[%s]", SuffixParam2)
 		end
 	end
-	
+
 	-------------
 	--- Death ---
 	-------------
-	
+
 	local delta = (death.time[destGUID] or 0) - timestamp
 	local isDeath = (delta>=0 and delta<latencyThreshold) or death.whosyourdaddy[destGUID]
-	
+
 	if S.DamageEvent[subevent] then
 		if not IsOption("Death") then return end
-		
+
 		if isDeath then
 			if subevent == "ENVIRONMENTAL_DAMAGE" then
 				local environmentalType, amount, _, _, _, _, absorb = select(12, unpack(CLEU))
@@ -553,14 +553,14 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 				death.overkill[destGUID] = RecycleTable(death.overkill[destGUID], event, unpack(CLEU))
 			end
 		end
-	
+
 	-- only announce death after UNIT_DIED fired, since the overkill parameter sometimes gives false positives/negatives
 	elseif subevent == "UNIT_DIED" then
 		if not IsOption("Death") then return end
-		
+
 		-- death handling
 		self:ShowDeath(destGUID, timestamp)
-		
+
 		-- store cleu event for if the unit possibly resurrects itself; very hacky
 		-- soulstone has precedence over reincarnation when cast on a shaman
 		if selfres.soulstone_source[destGUID] then -- confirm unit death with soulstone active
@@ -582,20 +582,20 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 			end
 			SwitchSourceDest(selfres.reincarnation[destGUID])
 		end
-		
+
 		return -- avoid double messages (the args from re-fired CLEU werent wiped)
-	
+
 	-- SPELL_INSTAKILL can fire on the same OnUpdate as UNIT_DIED, not sure if it can also fire later
 	elseif subevent == "SPELL_INSTAKILL" then
 		if IsOption("Death") and not S.Blacklist[spellID] then
 			SetMessage("Death_Instakill")
 			death.deleted[destGUID] = true -- dont announce death a second time
 		end
-	
+
 	------------
 	--- Miss ---
 	------------
-	
+
 	elseif S.MissEvent[subevent] then
 		-- (fatal) absorb event that still counts as damage
 		if SuffixParam1 == "ABSORB" then
@@ -611,7 +611,7 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 				SetMessage("Reflect")
 			end
 		else
-			local taunt = S.Taunt[spellID] and IsOption("Taunt") 
+			local taunt = S.Taunt[spellID] and IsOption("Taunt")
 			local int = S.Interrupt[spellID] and IsOption("Interrupt")
 			local cc = S.CrowdControl[spellID] and IsOption("CrowdControl")
 			if (taunt or int or cc) and not S.Blacklist[spellID] then
@@ -623,15 +623,15 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 				interrupt[sourceGUID] = false -- failed interrupt
 			end
 		end
-	
+
 	-----------------
 	--- Interrupt ---
 	-----------------
-	
+
 	elseif subevent == "SPELL_CAST_SUCCESS" then
 		if S.Interrupt[spellID] and IsOption("Juke") then
 			interrupt[sourceGUID] = true -- casted interrupt
-			
+
 			S.Timer:New(function()
 				if interrupt[sourceGUID] then -- wasted interrupt
 					-- need to fire another event since we are now delayed
@@ -640,7 +640,7 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 				interrupt[sourceGUID] = false
 			end, .5) -- wait for SPELL_INTERRUPT delay/lag
 		end
-	
+
 	-- show any and all interrupts
 	elseif subevent == "SPELL_INTERRUPT" then
 		if IsOption("Interrupt") then
@@ -649,24 +649,24 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 		if S.Interrupt[spellID] and IsOption("Juke") then
 			interrupt[sourceGUID] = false -- succesful interrupt
 		end
-	
+
 	elseif subevent == "SPELL_INTERRUPT_WASTED" then
 		SetMessage("Juke")
-	
+
 	------------
 	--- Aura ---
 	------------
-	
+
 	elseif subevent == "SPELL_AURA_APPLIED" then
 		if S.Taunt[spellID] and destType == "Creature" and IsOption("Taunt") then
 			-- guardian is also a npc
 			if bit_band(destFlags, COMBATLOG_OBJECT_TYPE_GUARDIAN) > 0 then return end
 			SetMessage("Taunt")
-		
+
 		-- Holy Priest 27827 [Spirit of Redemption] fix
 		elseif spellID == 27827 and IsOption("Death") then
 			-- fatal events can sometimes also happen right after e.g. the SPELL_AURA_APPLIED event
-			-- a single OnUpdate iteration later is enough to include those events as well		
+			-- a single OnUpdate iteration later is enough to include those events as well
 			S.Timer:New(function() self:ShowDeath(destGUID, timestamp) return end, 0)
 		-- Death Knight 116888 [Shroud of Purgatory], Mage 87023 [Cauterized] fix
 		elseif (spellID == 116888 or spellID == 87023) and IsOption("Death") then
@@ -679,7 +679,7 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 			if spellID == 605 and destGUID == sourceGUID then return end
 			SetMessage("CrowdControl")
 		end
-	
+
 	elseif subevent == "SPELL_AURA_REMOVED" then
 		-- Soulstone
 		if spellID == 20707 and IsOption("Resurrect") then
@@ -695,25 +695,25 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 		elseif (spellID == 116888 or spellID == 87023) and IsOption("Death") then
 			S.Timer:New(function() death.cheater[destGUID] = nil end, 1) -- in case of survival
 		end
-	
+
 	elseif subevent == "SPELL_AURA_BROKEN" then
 		-- track only for broken crowd control spells
 		if IsOption("Break") and S.CrowdControl[spellID] then
 			SetMessage(sourceName and "Break" or "Break_NoSource")
 		end
-	
+
 	elseif subevent == "SPELL_AURA_BROKEN_SPELL" then
 		if IsOption("Break") and S.CrowdControl[spellID] then
 			SetMessage("Break_Spell")
 		end
-	
+
 	--------------
 	--- Dispel ---
 	--------------
-	
+
 	elseif subevent == "SPELL_DISPEL" then
 		if not IsOption("Dispel") then return end
-		
+
 		local sourceReaction = UnitReaction(sourceFlags)
 		local destReaction = UnitReaction(destFlags)
 		local friendly = (sourceReaction == "Friendly" and destReaction == sourceReaction)
@@ -729,16 +729,16 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 				SetMessage("Dispel")
 			end
 		end
-	
+
 	elseif subevent == "SPELL_STOLEN" then
 		if IsOption("Dispel") and profile.Spellsteal then
 			SetMessage("Spellsteal")
 		end
-	
+
 	-----------------
 	--- Resurrect ---
 	-----------------
-	
+
 	elseif subevent == "SPELL_RESURRECT" then
 		if IsOption("Resurrect") and (not profile.CombatRes or UnitInCombat(sourceName)) then
 			SetMessage("Resurrect")
@@ -747,16 +747,16 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 		-- (which is technically also a combat res)
 		for k in pairs(selfres) do
 			selfres[k][destGUID] = nil
-		end		
-	
+		end
+
 	elseif subevent == "SPELL_RESURRECT_SELF" then
 		SetMessage(S.SelfResRemap[spellID])
 	end
-	
+
 	--------------------
 	--- Custom Spell ---
 	--------------------
-	
+
 	local suffix = strmatch(subevent, "SPELL_(.+)")
 	if spell[suffix] and spell[suffix][spellID] then -- kinda ugly part
 		local noDest = (S.SpellRemap[suffix] == "CAST_SUCCESS" and (not destName or S.SpellSummon[suffix])) and "_NO_DEST" or ""
@@ -770,14 +770,14 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 		args["local"] = bit_band(profile.SpellOutput, 0x1) > 0
 		args.chat = bit_band(profile.SpellOutput, 0x2) > 0
 	end
-	
+
 	------------
 	--- Unit ---
 	------------
-	
+
 	-- check if there is any message
 	if not args.msg then return end
-	
+
 	if sourceName then -- if no unit, then guid is an empty string and name is nil
 		-- trim out (CRZ) realm name; only do this for players
 		local name = (sourcePlayer and profile.TrimRealm) and strmatch(sourceName, "(.+)%-.+") or sourceName
@@ -788,29 +788,29 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 		if sourcePlayer and (profile.ColorEnemyPlayers or sourceReaction == "Friendly") then
 			color = S.ClassColor[GetPlayerClass[sourceGUID]]
 		end
-		
+
 		args.src = format("|cff%s"..TEXT_MODE_A_STRING_SOURCE_UNIT.."|r", color, sourceIconLocal, sourceGUID, sourceName, "["..fname.."]")
 		args.srcx = format("%s[%s]", sourceIconChat, name)
 	end
-	
+
 	if destName then
 		local isSelf = (destGUID == sourceGUID) and not isReverseEvent -- avoid "[Self] died from [Player][Spell]" if a unit died by its own damage
 		local name = isSelf and L.SELF or (destPlayer and profile.TrimRealm) and strmatch(destName, "(.+)%-.+") or destName
 		local fname = (destGUID == player.guid) and UNIT_YOU_DEST or name
 		local destIconLocal, destIconChat = UnitIcon(destRaidFlags, 2)
 		local destReaction = UnitReaction(destFlags)
-		local color = S.GeneralColor[destReaction] 
+		local color = S.GeneralColor[destReaction]
 		if destPlayer and (profile.ColorEnemyPlayers or destReaction == "Friendly") then
 			color = S.ClassColor[GetPlayerClass[destGUID]]
 		end
-		
+
 		args.dest = format("|cff%s"..TEXT_MODE_A_STRING_DEST_UNIT.."|r", color, destIconLocal, destGUID, destName, "["..fname.."]")
 		args.destx = format("%s[%s]", destIconChat, name)
 	end
-	
+
 	-- timestamp
 	local stamplocal, stampchat = S.GetTimestamp()
-	
+
 	-- remove braces again
 	if not profile.UnitBracesLocal then
 		-- src and dest args can be nil in rare cases
@@ -824,21 +824,21 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 		args.srcx = args.srcx and args.srcx:gsub(braces, "")
 		args.destx = args.destx and args.destx:gsub(braces, "")
 	end
-	
+
 	-- abbreviate numbers
 	if args.amount and type(args.amount) == "number" and profile.AbbreviateNumbers then
 		args.amount = AbbreviateLargeNumbers(args.amount)
 	end
-	
+
 	local resultString = (S.DamageEvent[subevent] or S.HealEvent[subevent]) and GetResultString(SuffixParam2, SuffixParam7, SuffixParam8, SuffixParam9) or ""
-	
+
 	local textLocal = stamplocal..ReplaceArgs(args)..resultString
 	local textChat = stampchat..ReplaceArgs(args, true)..resultString
-	
+
 	--------------
 	--- Output ---
 	--------------
-	
+
 	if args["local"] then
 		if profile.ChatWindow > 1 then
 			S.ChatFrame:AddMessage(textLocal, unpack(args.color))
@@ -846,7 +846,7 @@ function KCL:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
 		-- LibSink
 		self:Pour(profile.sink20OutputSink == "Channel" and textChat or textLocal, unpack(args.color))
 	end
-	
+
 	-- dont default to "SAY" if chatType is nil
 	if args.chat and profile.ChatChannel > 1 and chatType then
 		-- avoid ERR_CHAT_WHILE_DEAD
@@ -868,7 +868,7 @@ function KCL:ShowDeath(guid, timestamp)
 	if death.overkill[guid] and timestamp-death.overkill[guid][2] > latencyThreshold then
 		death.overkill[guid] = nil
 	end
-	
+
 	local cleu
 	local class = GetPlayerClass[guid]
 	if class == "HUNTER" and not guid == player.guid then -- UNIT_DIED is (98% of the time) genuine if the player is a hunter himself and died
@@ -882,13 +882,13 @@ function KCL:ShowDeath(guid, timestamp)
 	else -- prioritize any overkill events over normal dmg events
 		cleu = death.overkill[guid] or death.damage[guid]
 	end
-	
+
 	if cleu and not death.deleted[guid] then -- ignore instagibbed units
 		death.time[guid] = timestamp -- set death flag
 		-- fire the fatal event again; note that there are nil values in the table (from the environmental_damage event)
 		self:COMBAT_LOG_EVENT_UNFILTERED(unpack(cleu, 1, table_maxn(cleu)))
 	end
-	
+
 	-- reset death flag/data
 	for k in pairs(death) do
 		death[k][guid] = nil
@@ -905,17 +905,17 @@ end
 	2b rule out normal/combat resurrections by other people
 	3c rule out ress by the spirit healer or corpse running (already requires release spirit to ghost)
 	3  compare sudden health increase from zero to e.g. 60 percent
-	
+
 	if health == 0 or UnitIsDead == 1 then unit is in its corpse
 	if health == 1 or UnitIsGhost == 1 then unit released spirit and is a ghost
-	
+
 	Soulstone = 60% (.5999) health; 100% with [Glyph of Soulstone]
 	Reincarnation = 20%
 	Normal resurrection = 35%
 	Spirit Healer / corpse running = 50%
 	(Combat Res) Rebirth, Raise Ally = 60%; can be confused with Soulstone
 	[Darkmoon Card: Twisting Nether] = 20%; can be confused with Reincarnation
-	
+
 	soulstone has precedence over reincarnation when used on a shaman, only the soulstone will show as an option. reincarnation is not wasted
 	a normal resurrection overrides any soulstone/reincarnation for 1 minute, then soulstone/reincarnation will show again as an option
 	the soulstone buff on holy priests fades simultaenously with the guardian spirit buff. there are no problems afaik
@@ -924,17 +924,17 @@ end
 
 function KCL:UNIT_HEALTH(event, unit)
 	if not unit then return end -- 7.1 bug
-	
+
 	local guid = UnitGUID(unit) -- firstly filter out most of the stuff
 	if (not selfres.soulstone[guid] and not selfres.reincarnation[guid]) or not UnitIsVisible(unit) then return end
-	
+
 	local health = UnitHealth(unit)
 	local delta = (health-(selfres.prevHealth[guid] or 0)) / UnitHealthMax(unit)
 	selfres.prevHealth[guid] = health
-	
+
 	-- confirm unit is dead (again) for the subsequent UNIT_HEALTH event, where it should be alive
 	if UnitIsDead(unit) then selfres.wasDead[guid] = true; return end
-	
+
 	-- unit is now alive; check if it was previously dead
 	if selfres.wasDead[guid] then
 		if selfres.soulstone[guid] and (S.Approx(delta, .6, deviation) or S.Approx(delta, 1, deviation)) then
@@ -943,9 +943,9 @@ function KCL:UNIT_HEALTH(event, unit)
 			self:COMBAT_LOG_EVENT_UNFILTERED(unpack(selfres.reincarnation[guid]))
 		end
 	end
-	
+
 	-- reset self res data
 	for k in pairs(selfres) do
 		selfres[k][guid] = nil
-	end		
+	end
 end

--- a/Locales.lua
+++ b/Locales.lua
@@ -4,41 +4,41 @@ local L = {
 	enUS = {
 		EVENT_JUKE = "Juke",
 		EVENT_CROWDCONTROL = "Crowd Control",
-		
+
 		MSG_TAUNT = "<SRC><SPELL> taunted <DEST>",
-		
+
 		MSG_INTERRUPT = "<SRC><SPELL> "..ACTION_SPELL_INTERRUPT.." <DEST><XSPELL>",
 		MSG_JUKE = "<SRC> juked <SPELL> on <DEST>",
-		
+
 		MSG_DISPEL = "<SRC><SPELL> "..ACTION_SPELL_DISPEL_BUFF.." <DEST><XSPELL>",
 		MSG_CLEANSE = "<SRC><SPELL> "..ACTION_SPELL_DISPEL_DEBUFF.." <DEST><XSPELL>",
 		MSG_SPELLSTEAL = "<SRC><SPELL> "..ACTION_SPELL_STOLEN.." <DEST><XSPELL>",
-		
+
 		MSG_REFLECT = "<DEST> "..ACTION_SPELL_MISSED_REFLECT.." <SRC><SPELL>",
 		MSG_MISS = "<SRC><SPELL> on <DEST> "..ACTION_SPELL_CAST_FAILED.." (<TYPE>)",
-		
+
 		MSG_CROWDCONTROL = "<SRC><SPELL> CC'ed <DEST>",
 		-- this particular spell and extraspell order is extra confusing :x
 		MSG_BREAK_SPELL = "<SRC><XSPELL> "..ACTION_SPELL_AURA_BROKEN.." <DEST><SPELL>",
 		MSG_BREAK = "<SRC> "..ACTION_SPELL_AURA_BROKEN.." <DEST><SPELL>",
 		MSG_BREAK_NOSOURCE = "<SPELL> on <DEST> "..ACTION_SPELL_AURA_BROKEN,
-		
+
 		MSG_DEATH = "<DEST> "..ACTION_UNIT_DIED.." <SRC><SPELL> <AMOUNT> <SCHOOL>",
 		MSG_DEATH_MELEE = "<DEST> "..ACTION_UNIT_DIED.." <SRC> <AMOUNT> "..ACTION_SWING,
 		MSG_DEATH_ENVIRONMENTAL = "<DEST> "..ACTION_UNIT_DIED.." <AMOUNT> <TYPE>",
 		MSG_DEATH_INSTAKILL = "<SRC><SPELL> "..ACTION_SPELL_INSTAKILL.." <DEST>",
-		
+
 		MSG_SAVE = "<SRC><SPELL> saved <DEST> <AMOUNT> <SCHOOL>",
 		MSG_RESURRECT = "<SRC><SPELL> "..ACTION_SPELL_RESURRECT.." <DEST>",
 		-- source and dest are switched
 		MSG_SELFRES_SOULSTONE = "<SRC> used <DEST><SPELL>",
 		MSG_SELFRES_REINCARNATION = "<SRC> "..ACTION_SPELL_CAST_SUCCESS.." <SPELL>",
-		
+
 		LOCAL = "Local",
 		SELF = "Self",
 		ENEMY_PLAYERS_CLASS_COLORS = "Color enemy players by class",
 		ABBREVIATE_LARGE_NUMBERS = "Abbreviate Large Numbers",
-		
+
 		USE_CLASS_COLORS = "Please use the |cff71D5FFClass Colors|r AddOn",
 		BROKER_CLICK = "|cffFFFFFFClick|r to open the options menu",
 		BROKER_SHIFT_CLICK = "|cffFFFFFFShift-click|r to toggle this AddOn",
@@ -70,7 +70,7 @@ local L = {
 		MSG_SPELLSTEAL = "<SRC><SPELL> stahl <DEST><XSPELL>",
 		MSG_TAUNT = "<SRC><SPELL> verspottete <DEST>",
 		SELF = "Selbst",
-		
+
 		USE_CLASS_COLORS = "Bitte benützt dafür das |cff71D5FFClass Colors|r AddOn",
 		BROKER_CLICK = "|cffFFFFFFKlickt|r, um das Optionsmenü zu öffnen",
 		BROKER_SHIFT_CLICK = "|cffFFFFFFShift-klickt|r, um dieses AddOn ein-/auszuschalten",
@@ -122,7 +122,7 @@ local L = {
 	},
 	zhCN = {
 		SELF = "自己",
-		
+
 		USE_CLASS_COLORS = "请使用 |cff71D5FFClassColors|r 插件", -- Needs review
 		BROKER_CLICK = "|cffFFFFFF点击|r打开选项菜单",
 		BROKER_SHIFT_CLICK = "|cffFFFFFFrShift-点击|r 启用或禁用插件",

--- a/Options.lua
+++ b/Options.lua
@@ -37,14 +37,14 @@ S.defaults = { -- KethoCombatLog.db.defaults
 		LocalTaunt = true,
 		LocalInterrupt = true,
 		LocalDeath = true,
-		
+
 		PvE = true,
 		PvP = true,
 		World = true,
-		
+
 		ChatWindow = 2, -- ChatFrame1
 		ChatChannel = 1, -- Disabled
-		
+
 		TrimRealm = true,
 		Timestamp = 1, -- None
 		IconSize = 16,
@@ -53,17 +53,17 @@ S.defaults = { -- KethoCombatLog.db.defaults
 		CriticalFormat = true,
 		AbbreviateNumbers = true,
 		BlizzardCombatLog = true,
-		
+
 		FilterPlayers = true, -- inclusive filtering
 		TankTaunt = true,
 		PetTaunt = true,
 		FriendlyDispel = true,
 		HostileDispel = true,
 		Spellsteal = true,
-		
+
 		SpellOutput = 1,
 		SpellFilterSelf = true, -- exclusive filtering
-		
+
 		color = {
 			Taunt = {1, 0, 0}, -- #FF0000 (Red)
 			Interrupt = {0, 110/255, 1}, -- #006EFF (something Blue)
@@ -89,40 +89,40 @@ S.defaults = { -- KethoCombatLog.db.defaults
 			Unknown = {191/255, 191/255, 191/255}, -- #BFBFBF
 			Timestamp = {0.67, 0.67, 0.67},
 		},
-		
+
 		message = {
 			Taunt = L.MSG_TAUNT,
-			
+
 			Interrupt = L.MSG_INTERRUPT,
 			Juke = L.MSG_JUKE,
-			
+
 			Dispel = L.MSG_DISPEL,
 			Cleanse = L.MSG_CLEANSE,
 			Spellsteal = L.MSG_SPELLSTEAL,
-			
+
 			Reflect = L.MSG_REFLECT,
 			Miss = L.MSG_MISS,
-			
+
 			CrowdControl = L.MSG_CROWDCONTROL,
 			Break = L.MSG_BREAK,
 			Break_NoSource = L.MSG_BREAK_NOSOURCE,
 			Break_Spell = L.MSG_BREAK_SPELL,
-			
+
 			Death = L.MSG_DEATH,
 			Death_Melee = L.MSG_DEATH_MELEE,
 			Death_Environmental = L.MSG_DEATH_ENVIRONMENTAL,
 			Death_Instakill = L.MSG_DEATH_INSTAKILL,
-			
+
 			Save = L.MSG_SAVE,
 			Resurrect = L.MSG_RESURRECT,
 			Soulstone = L.MSG_SELFRES_SOULSTONE,
 			Reincarnation = L.MSG_SELFRES_REINCARNATION,
-			
+
 			CAST_START = S.SpellMsg.unit.CAST_START,
 			CAST_SUCCESS_NO_DEST = S.SpellMsg.unit.CAST_SUCCESS_NO_DEST,
 			CAST_SUCCESS = S.SpellMsg.unit.CAST_SUCCESS,
 		},
-		
+
 		sink20OutputSink = "None",
 	},
 }
@@ -208,7 +208,7 @@ S.options = {
 						-- 	local name = chanList[i+1]
 						-- 	channels[chanList[i]] = strfind(name, "Community:") and ChatFrame_ResolveChannelName(name) or name
 						-- end
-						
+
 						-- for i = 1, MAX_WOW_CHAT_CHANNELS do
 						-- 	if channels[i] then
 						-- 		ChatChannelList[i+4] = "|cff2E9AFE"..i..".|r  "..channels[i]
@@ -248,7 +248,7 @@ S.options = {
 							end,
 						},
 						IconSize = {
-							type = "select", order = 3, descStyle = "", 
+							type = "select", order = 3, descStyle = "",
 							name = "|cffFFFFFF"..EMBLEM_SYMBOL.." Size|r",
 							values = S.IconValues,
 						},
@@ -545,29 +545,29 @@ end
 
 do
 	local o = options.args.Main.args.Local.args
-	
+
 	for i, v in ipairs(S.Event) do
 		o["Chat"..v] = {
 			type = "toggle", order = i*2, width = .12,
 			desc = CHAT.." "..CHANNEL,
 			name = " ",
 		}
-		
+
 		o["Local"..v] = {
 			type = "toggle", order = i*2,
 			desc = CHAT.." Window",
 			name = function() return format("|TInterface\\Icons\\%s:16:16:1:0%s|t  |cff%s%s|r", S.EventString[v][2], S.crop, S.GeneralColor[v], S.EventString[v][1]) end,
 		}
 	end
-	
-	-- (un)register UNIT_HEALTH according to options 
+
+	-- (un)register UNIT_HEALTH according to options
 	local function SetResurrect(i, v)
 		profile[i[#i]] = v
 		KCL:RefreshEvent()
 	end
 	o.LocalResurrect.set = SetResurrect
 	o.ChatResurrect.set = SetResurrect
-	
+
 	for i = 1, 4 do
 		o["newline"..i] = {type = "description", order = 1+i*4, name = ""}
 	end
@@ -579,7 +579,7 @@ end
 
 do
 	local o = options.args.Advanced.args.Spell.args
-	
+
 	for i, v in ipairs(S.SpellMsgOptionKey) do
 		o[v] = {
 			type = "input", order = i+30,
@@ -592,7 +592,7 @@ end
 
 do
 	local o = options.args.Advanced.args.Message.args
-	
+
 	for i, v in ipairs(S.EventMsg) do
 		o[v] = {
 			type = "input", order = i,
@@ -605,7 +605,7 @@ end
 do
 	local o = options.args.Advanced.args.Coloring.args
 	local colorWidth = .9
-	
+
 	for i, v in ipairs(S.Event) do
 		o[v] = {
 			type = "color", order = 2+i, -- 3-12
@@ -614,7 +614,7 @@ do
 			set = "SetGeneralColor",
 		}
 	end
-	
+
 	if CUSTOM_CLASS_COLORS then
 		o.notification = {
 			type = "description", order = 21,
@@ -632,7 +632,7 @@ do
 			}
 		end
 	end
-	
+
 	for i, v in pairs(S.School) do
 		o[v] = {
 			type = "color", order = 40+i, -- 41-47
@@ -641,7 +641,7 @@ do
 			set = "SetClassColor",
 		}
 	end
-	
+
 	for i, v in ipairs{2, 20, 40, 50, 54} do
 		o["header"..i] = {type = "header", order = v, name = ""}
 	end
@@ -667,7 +667,7 @@ function KCL:DataFrame()
 	if not KethoCombatLogData then
 		local f = CreateFrame("Frame", "KethoCombatLogData", UIParent, "DialogBoxFrame")
 		f:SetPoint("CENTER"); f:SetSize(600, 500)
-		
+
 		f:SetBackdrop({
 			bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
 			edgeFile = "Interface\\PVPFrame\\UI-Character-PVP-Highlight", -- this one is neat
@@ -675,11 +675,11 @@ function KCL:DataFrame()
 			insets = { left = 8, right = 6, top = 8, bottom = 8 },
 		})
 		f:SetBackdropBorderColor(0, .44, .87, 0.5)
-		
+
 	---------------
 	--- Movable ---
 	---------------
-		
+
 		f:EnableMouse(true) -- also seems to be automatically enabled when setting the OnMouseDown script
 		f:SetMovable(true); f:SetClampedToScreen(true)
 		f:SetScript("OnMouseDown", function(self, button)
@@ -688,24 +688,24 @@ function KCL:DataFrame()
 			end
 		end)
 		f:SetScript("OnMouseUp", f.StopMovingOrSizing)
-		
+
 	-------------------
 	--- ScrollFrame ---
 	-------------------
-		
+
 		local sf = CreateFrame("ScrollFrame", "KethoCombatLogDataScrollFrame", KethoCombatLogData, "UIPanelScrollFrameTemplate")
 		sf:SetPoint("LEFT", 16, 0)
 		sf:SetPoint("RIGHT", -32, 0)
 		sf:SetPoint("TOP", 0, -16)
 		sf:SetPoint("BOTTOM", KethoCombatLogDataButton, "TOP", 0, 0)
-		
+
 	---------------
 	--- EditBox ---
 	---------------
-		
+
 		local eb = CreateFrame("EditBox", "KethoCombatLogDataEditBox", KethoCombatLogDataScrollFrame)
 		eb:SetSize(sf:GetSize()) -- seems inheriting the points won't automatically set the width/size
-		
+
 		eb:SetMultiLine(true)
 		eb:SetFontObject("ChatFontNormal")
 		eb:SetAutoFocus(false) -- make keyboard not automatically focused to this editbox
@@ -713,27 +713,27 @@ function KCL:DataFrame()
 			--self:ClearFocus()
 			f:Hide() -- rather hide, since we only use it for copying to clipboard
 		end)
-		
+
 		sf:SetScrollChild(eb)
-		
+
 	-----------------
 	--- Resizable ---
 	-----------------
-		
+
 		f:SetResizable(true)
 		f:SetMinResize(150, 100) -- at least show the "okay" button
-		
+
 		local rb = CreateFrame("Button", "KethoCombatLogDataResizeButton", KethoCombatLogData)
 		rb:SetPoint("BOTTOMRIGHT", -6, 7); rb:SetSize(16, 16)
-		
+
 		rb:SetNormalTexture("Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Up")
 		rb:SetHighlightTexture("Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Highlight")
 		rb:SetPushedTexture("Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Down")
-		
+
 		rb:SetScript("OnMouseDown", function(self, button)
 			if button == "LeftButton" then
 				f:StartSizing("BOTTOMRIGHT")
-				self:GetHighlightTexture():Hide() -- we only want to see the PushedTexture now 
+				self:GetHighlightTexture():Hide() -- we only want to see the PushedTexture now
 			end
 		end)
 		rb:SetScript("OnMouseUp", function(self, button)
@@ -741,18 +741,18 @@ function KCL:DataFrame()
 			self:GetHighlightTexture():Show()
 			eb:SetWidth(sf:GetWidth()) -- update editbox to the new scrollframe width
 		end)
-		
+
 		f:Show()
 	else
 		KethoCombatLogData:Show()
 	end
-	
+
 	if ACD.OpenFrames.KethoCombatLog_Parent then
 		-- the ACD window's Strata is "FULLSCREEN_DIALOG", and changing FrameLevels seems troublesome
 		KethoCombatLogData:SetFrameStrata("TOOLTIP")
 	end
 	GameTooltip:Hide() -- most likely the popup frame will prevent the GameTooltip's OnLeave script from firing
-	
+
 	SpellDataString = SpellDataString or self:GetSpellData() -- around 6500 string length
 	KethoCombatLogDataEditBox:SetText(SpellDataString)
 end


### PR DESCRIPTION
The first commit just updates VS code metadata and trims trailing whitespace.  To see the relevant change, see the second commit.